### PR TITLE
🛡️ Sentinel: [MEDIUM] Redact sensitive data in debug logs

### DIFF
--- a/backend/core/logger.ts
+++ b/backend/core/logger.ts
@@ -1,6 +1,53 @@
+import { redactSensitiveText } from './redaction';
+
 const DEBUG_ENABLED = process.env.ACOPILOT_DEBUG === '1' || process.env.ACOPILOT_DEBUG === 'true';
+
+function redactValue(value: unknown, seen = new WeakSet()): unknown {
+  if (value === null || value === undefined) return value;
+
+  if (typeof value === 'string') {
+    return redactSensitiveText(value);
+  }
+
+  if (typeof value === 'object') {
+    if (seen.has(value as object)) {
+      return '[Circular]';
+    }
+    seen.add(value as object);
+
+    if (Array.isArray(value)) {
+      return value.map(item => redactValue(item, seen));
+    }
+
+    if (value instanceof Error) {
+      return {
+        name: value.name,
+        message: redactSensitiveText(value.message),
+        stack: value.stack ? redactSensitiveText(value.stack) : undefined,
+        // Clone other properties if any
+        ...Object.fromEntries(
+          Object.entries(value).map(([k, v]) => [k, redactValue(v, seen)])
+        )
+      };
+    }
+
+    // Handle plain objects
+    const redactedObj: Record<string, unknown> = {};
+    for (const key in value) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
+        redactedObj[key] = redactValue((value as Record<string, unknown>)[key], seen);
+      }
+    }
+    return redactedObj;
+  }
+
+  return value;
+}
 
 export function debugLog(...args: unknown[]): void {
   if (!DEBUG_ENABLED) return;
-  console.log(...args);
+
+  const redactedArgs = args.map(arg => redactValue(arg));
+
+  console.log(...redactedArgs);
 }

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('debugLog', () => {
+  let consoleSpy: any;
+  let debugLog: any;
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.env = { ...originalEnv, ACOPILOT_DEBUG: 'true' };
+    vi.resetModules();
+    const loggerModule = await import('../backend/core/logger');
+    debugLog = loggerModule.debugLog;
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  it('should redact sensitive information in strings', () => {
+    const sensitiveString = 'This is a secret key: sk-abcdef1234567890';
+    debugLog(sensitiveString);
+
+    // Should be called with redacted string
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('***REDACTED***'));
+    // Should NOT be called with the original secret
+    expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('sk-abcdef1234567890'));
+  });
+
+  it('should not redact non-sensitive strings', () => {
+    const normalString = 'This is a normal log message';
+    debugLog(normalString);
+    expect(consoleSpy).toHaveBeenCalledWith(normalString);
+  });
+
+  it('should redact sensitive information in multiple arguments', () => {
+    debugLog('Log:', 'Authorization: Bearer sk-1234567890');
+    expect(consoleSpy).toHaveBeenCalledWith('Log:', expect.stringContaining('***REDACTED***'));
+  });
+
+  it('should redact sensitive information in objects', () => {
+    const sensitiveObject = {
+      user: 'admin',
+      token: 'sk-abcdef1234567890',
+      nested: {
+        apiKey: 'sk-abcdef1234567890'
+      }
+    };
+    debugLog(sensitiveObject);
+
+    // Verify call arguments
+    const loggedArg = consoleSpy.mock.calls[0][0];
+    expect(loggedArg.token).toContain('***REDACTED***');
+    expect(loggedArg.nested.apiKey).toContain('***REDACTED***');
+    expect(loggedArg.user).toBe('admin');
+  });
+
+  it('should handle circular references', () => {
+    const circular: any = { name: 'circular' };
+    circular.self = circular;
+    debugLog(circular);
+    const loggedArg = consoleSpy.mock.calls[0][0];
+    expect(loggedArg.self).toBe('[Circular]');
+  });
+
+  it('should redact sensitive information in Errors', () => {
+    const error = new Error('Failed with token sk-abcdef1234567890');
+    debugLog(error);
+    const loggedArg = consoleSpy.mock.calls[0][0];
+    expect(loggedArg.message).toContain('***REDACTED***');
+    expect(loggedArg.message).not.toContain('sk-abcdef1234567890');
+  });
+});


### PR DESCRIPTION
**Vulnerability:** Debug logs could expose sensitive data (API keys, tokens) if developers accidentally logged objects containing them.
**Fix:** Enhanced `debugLog` in `backend/core/logger.ts` to recursively traverse objects and arrays, applying `redactSensitiveText` to all string values.
**Verification:** Added `test/logger.test.ts` which verifies that sensitive strings, nested objects, and Errors are correctly redacted. ran `pnpm test` to confirm all tests pass.

---
*PR created automatically by Jules for task [10465357583309903207](https://jules.google.com/task/10465357583309903207) started by @Andy963*