### PR TITLE
Checkpoint: refine concurrent hashing/copy implementation

### DIFF
--- a/backend/modules/checkpoint/CheckpointManager.ts
+++ b/backend/modules/checkpoint/CheckpointManager.ts
@@ -25,6 +25,7 @@ import { getDiffManager } from '../../tools/file/diffManager';
 import { cleanupEmptyDirsRecursive, collectFilesAndDirsWithPatterns, loadAllGitignorePatterns } from './checkpointFs';
 import type { CheckpointRecord, FileChange } from './checkpointTypes';
 import { restoreCheckpointLegacy } from './checkpointLegacyRestore';
+import { getCheckpointIoConcurrency, runWithConcurrency } from './concurrency';
 
 export type { CheckpointRecord, FileChange } from './checkpointTypes';
 
@@ -138,18 +139,26 @@ export class CheckpointManager {
             
             // 计算当前所有文件的哈希
             const currentHashes: Record<string, string> = {};
-            const hashParts: string[] = [];
             const sortedFiles = [...files].sort();
-            
-            for (const file of sortedFiles) {
+
+            const hashConcurrency = getCheckpointIoConcurrency(sortedFiles.length);
+            await runWithConcurrency(sortedFiles, hashConcurrency, async (file) => {
                 try {
                     const relativePath = path.relative(workspaceRoot.fsPath, file);
                     const content = await fs.readFile(file);
                     const fileHash = crypto.createHash('md5').update(content).digest('hex');
                     currentHashes[relativePath] = fileHash;
-                    hashParts.push(`${relativePath}:${fileHash}`);
                 } catch (err) {
                     console.warn(`[CheckpointManager] Failed to hash ${file}:`, err);
+                }
+            });
+
+            const hashParts: string[] = [];
+            for (const file of sortedFiles) {
+                const relativePath = path.relative(workspaceRoot.fsPath, file);
+                const fileHash = currentHashes[relativePath];
+                if (fileHash) {
+                    hashParts.push(`${relativePath}:${fileHash}`);
                 }
             }
             
@@ -204,12 +213,12 @@ export class CheckpointManager {
                 ];
                 
                 // 只复制变更的文件（如果没有变更，则不复制任何文件）
-                for (const change of changes) {
-                    if (change.type === 'deleted') continue;
-                    
+                const incrementalCopyChanges = changes.filter(change => change.type !== 'deleted');
+                const incrementalCopyConcurrency = getCheckpointIoConcurrency(incrementalCopyChanges.length);
+                await runWithConcurrency(incrementalCopyChanges, incrementalCopyConcurrency, async (change) => {
                     const srcPath = path.join(workspaceRoot.fsPath, change.path);
                     const destPath = path.join(backupDir, change.path);
-                    
+
                     try {
                         await fs.mkdir(path.dirname(destPath), { recursive: true });
                         await fs.copyFile(srcPath, destPath);
@@ -217,25 +226,26 @@ export class CheckpointManager {
                     } catch (err) {
                         console.warn(`[CheckpointManager] Failed to copy ${change.path}:`, err);
                     }
-                }
+                });
                 
                 debugLog(`[CheckpointManager] Incremental backup: ${added.length} added, ${modified.length} modified, ${deleted.length} deleted`);
             }
             
             // 如果不是增量备份，进行完整备份
             if (!isIncremental) {
-                for (const file of sortedFiles) {
+                const fullCopyConcurrency = getCheckpointIoConcurrency(sortedFiles.length);
+                await runWithConcurrency(sortedFiles, fullCopyConcurrency, async (file) => {
                     try {
                         const relativePath = path.relative(workspaceRoot.fsPath, file);
                         const destPath = path.join(backupDir, relativePath);
-                        
+
                         await fs.mkdir(path.dirname(destPath), { recursive: true });
                         await fs.copyFile(file, destPath);
                         fileCount++;
                     } catch (err) {
                         console.warn(`[CheckpointManager] Failed to copy ${file}:`, err);
                     }
-                }
+                });
                 
                 // 备份空目录
                 for (const dir of dirs) {

--- a/backend/modules/checkpoint/concurrency.ts
+++ b/backend/modules/checkpoint/concurrency.ts
@@ -1,0 +1,42 @@
+export const CHECKPOINT_IO_CONCURRENCY_ENV = 'ACOPILOT_CHECKPOINT_IO_CONCURRENCY';
+export const DEFAULT_CHECKPOINT_IO_CONCURRENCY = 16;
+export const MAX_CHECKPOINT_IO_CONCURRENCY = 64;
+
+function parsePositiveInt(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+export function getCheckpointIoConcurrency(itemCount: number): number {
+  if (itemCount <= 0) return 0;
+
+  const requested = parsePositiveInt(process.env[CHECKPOINT_IO_CONCURRENCY_ENV]);
+  const base = requested ?? DEFAULT_CHECKPOINT_IO_CONCURRENCY;
+  const bounded = Math.max(1, Math.min(base, MAX_CHECKPOINT_IO_CONCURRENCY));
+
+  return Math.min(bounded, itemCount);
+}
+
+export async function runWithConcurrency<T>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return;
+
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: limit }, async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      await fn(items[index], index);
+    }
+  });
+
+  await Promise.all(workers);
+}
+

--- a/test/checkpointConcurrency.test.ts
+++ b/test/checkpointConcurrency.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHECKPOINT_IO_CONCURRENCY_ENV,
+  DEFAULT_CHECKPOINT_IO_CONCURRENCY,
+  MAX_CHECKPOINT_IO_CONCURRENCY,
+  getCheckpointIoConcurrency,
+  runWithConcurrency,
+} from '../backend/modules/checkpoint/concurrency';
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('getCheckpointIoConcurrency', () => {
+  it('returns 0 for empty work', () => {
+    expect(getCheckpointIoConcurrency(0)).toBe(0);
+  });
+
+  it('uses default when env is unset', () => {
+    const previous = process.env[CHECKPOINT_IO_CONCURRENCY_ENV];
+    delete process.env[CHECKPOINT_IO_CONCURRENCY_ENV];
+    try {
+      expect(getCheckpointIoConcurrency(999)).toBe(DEFAULT_CHECKPOINT_IO_CONCURRENCY);
+    } finally {
+      if (previous === undefined) {
+        delete process.env[CHECKPOINT_IO_CONCURRENCY_ENV];
+      } else {
+        process.env[CHECKPOINT_IO_CONCURRENCY_ENV] = previous;
+      }
+    }
+  });
+
+  it('respects env override and caps to itemCount', () => {
+    const previous = process.env[CHECKPOINT_IO_CONCURRENCY_ENV];
+    process.env[CHECKPOINT_IO_CONCURRENCY_ENV] = '2';
+    try {
+      expect(getCheckpointIoConcurrency(10)).toBe(2);
+    } finally {
+      if (previous === undefined) {
+        delete process.env[CHECKPOINT_IO_CONCURRENCY_ENV];
+      } else {
+        process.env[CHECKPOINT_IO_CONCURRENCY_ENV] = previous;
+      }
+    }
+  });
+
+  it('caps env override to MAX_CHECKPOINT_IO_CONCURRENCY', () => {
+    const previous = process.env[CHECKPOINT_IO_CONCURRENCY_ENV];
+    process.env[CHECKPOINT_IO_CONCURRENCY_ENV] = String(MAX_CHECKPOINT_IO_CONCURRENCY + 1000);
+    try {
+      expect(getCheckpointIoConcurrency(999)).toBe(MAX_CHECKPOINT_IO_CONCURRENCY);
+    } finally {
+      if (previous === undefined) {
+        delete process.env[CHECKPOINT_IO_CONCURRENCY_ENV];
+      } else {
+        process.env[CHECKPOINT_IO_CONCURRENCY_ENV] = previous;
+      }
+    }
+  });
+});
+
+describe('runWithConcurrency', () => {
+  it('processes all items exactly once', async () => {
+    const items = Array.from({ length: 25 }, (_, index) => index);
+    const seen = new Set<number>();
+
+    await runWithConcurrency(items, 4, async (item) => {
+      await delay(1);
+      seen.add(item);
+    });
+
+    expect(seen.size).toBe(items.length);
+  });
+
+  it('does not exceed provided concurrency', async () => {
+    const items = Array.from({ length: 20 }, (_, index) => index);
+    let active = 0;
+    let maxActive = 0;
+
+    await runWithConcurrency(items, 3, async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await delay(5);
+      active--;
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(3);
+  });
+
+  it('caps concurrency to item length', async () => {
+    const items = [1, 2];
+    let active = 0;
+    let maxActive = 0;
+
+    await runWithConcurrency(items, 999, async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await delay(5);
+      active--;
+    });
+
+    expect(maxActive).toBe(2);
+  });
+
+  it('no-ops for empty lists', async () => {
+    let called = false;
+
+    await runWithConcurrency([], 10, async () => {
+      called = true;
+    });
+
+    expect(called).toBe(false);
+  });
+});
+


### PR DESCRIPTION
Fixes #6.

This PR replaces Jules' PR #2 with an improved and cleaner implementation.

## What changed
- Introduced `runWithConcurrency` with an index-based dispatcher (avoids `queue.shift()` overhead).
- Reused the helper across hashing, incremental copy, and full copy to remove duplicated worker boilerplate.
- Replaced the hard-coded concurrency with a safer default + bounded override via `ACOPILOT_CHECKPOINT_IO_CONCURRENCY` (also capped by `items.length`).
- Preserved deterministic `contentHash` by reconstructing `hashParts` in `sortedFiles` order.
- Added unit tests for concurrency helpers.

## Not included
- No `.jules/` artifacts.
