### PR TITLE
🎨 Palette: Improve SendButton accessibility and focus management

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Focus Preservation on Button State Change
+**Learning:** Switching between two buttons using `v-if`/`v-else` (e.g., Send vs. Stop) causes keyboard focus to be lost when the state changes. This is disorienting for screen reader and keyboard-only users.
+**Action:** Use a single `<button>` element and dynamically bind its properties (icon, title, aria-label, click handler) to preserve focus during state transitions.

--- a/frontend/src/components/input/SendButton.vue
+++ b/frontend/src/components/input/SendButton.vue
@@ -5,11 +5,12 @@
  * loading 状态下显示停止图标，点击可取消请求
  */
 
+import { computed } from 'vue'
 import { useI18n } from '../../i18n'
 
 const { t } = useI18n()
 
-defineProps<{
+const props = defineProps<{
   disabled?: boolean
   loading?: boolean
 }>()
@@ -19,37 +20,41 @@ const emit = defineEmits<{
   cancel: []
 }>()
 
+// 按钮状态计算
+const buttonState = computed(() => {
+  if (props.loading) {
+    return {
+      title: t('components.input.stopGenerating'),
+      icon: 'codicon codicon-primitive-square stop-icon',
+      isDisabled: false
+    }
+  }
+  return {
+    title: t('components.input.send'),
+    icon: 'codicon codicon-send send-icon',
+    isDisabled: props.disabled
+  }
+})
+
 // 处理点击
 function handleClick() {
-  emit('click')
-}
-
-// 处理取消
-function handleCancel() {
-  emit('cancel')
+  if (props.loading) {
+    emit('cancel')
+  } else {
+    emit('click')
+  }
 }
 </script>
 
 <template>
-  <!-- 取消按钮 - loading 状态下显示 -->
   <button
-    v-if="loading"
     class="send-button"
-    :title="t('components.input.stopGenerating')"
-    @click="handleCancel"
-  >
-    <i class="codicon codicon-primitive-square stop-icon"></i>
-  </button>
-  
-  <!-- 发送按钮 - 正常状态下显示 -->
-  <button
-    v-else
-    class="send-button"
-    :disabled="disabled"
-    :title="t('components.input.send')"
+    :disabled="buttonState.isDisabled"
+    :title="buttonState.title"
+    :aria-label="buttonState.title"
     @click="handleClick"
   >
-    <i class="codicon codicon-send send-icon"></i>
+    <i :class="buttonState.icon"></i>
   </button>
 </template>
 


### PR DESCRIPTION
💡 What: Refactored `SendButton.vue` to use a single `<button>` element with computed properties instead of `v-if`/`v-else`.
🎯 Why: Toggling between two separate button elements causes keyboard focus to be lost when the state changes (e.g., from "Send" to "Stop"). This is a jarring experience for keyboard and screen reader users.
♿ Accessibility:
- Preserves focus on the button during state transitions.
- Added explicit `aria-label` attribute to the button, mirroring the tooltip title.
- Improved semantic structure by using a single interactive element.

---
*PR created automatically by Jules for task [709905056640331359](https://jules.google.com/task/709905056640331359) started by @Andy963*