### PR TITLE
🛡️ Sentinel: Fix command obfuscation bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Command Risk Assessment Obfuscation Bypass
+**Vulnerability:** Shell command risk assessment using regex can be bypassed by simple obfuscation like quotes and backslashes (e.g., `'rm' -rf /`, `\rm -rf /`).
+**Learning:** Regex-based security checks on raw command strings are insufficient without normalization.
+**Prevention:** Normalize commands by stripping quotes and escape characters before applying risk patterns.

--- a/backend/core/commandRisk.ts
+++ b/backend/core/commandRisk.ts
@@ -65,9 +65,15 @@ function normalizeCommand(command: string): string {
   return (command || '').trim();
 }
 
+function stripQuotesAndEscapes(command: string): string {
+  // Remove single quotes, double quotes, and backslashes to prevent bypass
+  return command.replace(/['"\\]/g, '');
+}
+
 function computeRiskFromCommand(command: string): Omit<CommandRiskAssessment, 'matchedAllowPattern' | 'matchedDenyPattern'> {
   const cmd = normalizeCommand(command);
-  const lower = cmd.toLowerCase();
+  const strippedCmd = stripQuotesAndEscapes(cmd);
+  const lower = strippedCmd.toLowerCase();
 
   const categories: CommandRiskCategory[] = [];
   const reasons: string[] = [];

--- a/test/commandRiskBypass.test.ts
+++ b/test/commandRiskBypass.test.ts
@@ -1,0 +1,41 @@
+
+import { describe, expect, it } from 'vitest';
+import { assessExecuteCommandRisk } from '../backend/core/commandRisk';
+
+describe('assessExecuteCommandRisk Bypass Check', () => {
+  it('flags quoted rm command as critical', () => {
+    const risk = assessExecuteCommandRisk("'rm' -rf /");
+    expect(risk.level).toBe('critical');
+    expect(risk.categories).toContain('destructive');
+  });
+
+  it('flags double quoted rm command as critical', () => {
+    const risk = assessExecuteCommandRisk('"rm" -rf /');
+    expect(risk.level).toBe('critical');
+    expect(risk.categories).toContain('destructive');
+  });
+
+  it('flags backslash escaped rm command as critical', () => {
+    const risk = assessExecuteCommandRisk("\\rm -rf /");
+    expect(risk.level).toBe('critical');
+    expect(risk.categories).toContain('destructive');
+  });
+
+  it('flags interleaved backslash rm command as critical', () => {
+    const risk = assessExecuteCommandRisk("r\\m -rf /");
+    expect(risk.level).toBe('critical');
+    expect(risk.categories).toContain('destructive');
+  });
+
+  it('flags mixed quotes rm command as critical', () => {
+    const risk = assessExecuteCommandRisk("'r'\"m\" -rf /");
+    expect(risk.level).toBe('critical');
+    expect(risk.categories).toContain('destructive');
+  });
+
+  it('flags quoted git reset --hard as high', () => {
+    const risk = assessExecuteCommandRisk("'git' reset --hard");
+    expect(risk.level).toBe('high');
+    expect(risk.categories).toContain('gitHistory');
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix command obfuscation bypass

🚨 Severity: HIGH
💡 Vulnerability: Shell commands could bypass risk assessment using quotes and backslashes (e.g., "'rm' -rf /").
🎯 Impact: Allows execution of dangerous commands without triggering warnings.
🔧 Fix: Strip quotes and backslashes from command string before risk assessment.
✅ Verification: Added new test suite `test/commandRiskBypass.test.ts` verifying obfuscated commands are now flagged correctly.

---
*PR created automatically by Jules for task [14471049438521781471](https://jules.google.com/task/14471049438521781471) started by @Andy963*