### PR TITLE
🎨 Palette: Improve Tooltip keyboard accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Tooltip Keyboard Accessibility
+**Learning:** The custom `Tooltip` component relied solely on `mouseenter`/`mouseleave`, making it inaccessible to keyboard users. This affected all icon-only buttons wrapped in tooltips.
+**Action:** Always ensure tooltips and interactive wrappers support `focusin`/`focusout` events to expose context to keyboard users.

--- a/frontend/src/components/common/Tooltip.vue
+++ b/frontend/src/components/common/Tooltip.vue
@@ -32,7 +32,13 @@ function hide() {
 </script>
 
 <template>
-  <div class="tooltip-wrapper" @mouseenter="show" @mouseleave="hide">
+  <div
+    class="tooltip-wrapper"
+    @mouseenter="show"
+    @mouseleave="hide"
+    @focusin="show"
+    @focusout="hide"
+  >
     <slot />
     <Transition name="tooltip-fade">
       <div


### PR DESCRIPTION
💡 What: Added `focusin` and `focusout` event listeners to the `Tooltip` component.
🎯 Why: Tooltips were only triggered by mouse hover (`mouseenter`/`mouseleave`), making icon-only buttons (which rely on tooltips for labels) inaccessible to keyboard users. This change ensures tooltips appear when their content receives focus.
📸 Before/After: Verified locally using Playwright script. Tooltips now appear on focus.
♿ Accessibility: Enables keyboard users to perceive tooltip content, which is critical for understanding icon-only controls.

---
*PR created automatically by Jules for task [16445483212042621891](https://jules.google.com/task/16445483212042621891) started by @Andy963*