### PR TITLE
🛡️ Sentinel: Prevent MCP servers from inheriting sensitive environment variables

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-19 - MCP Environment Isolation
+**Vulnerability:** MCP servers spawned via `stdio` transport inherited the entire `process.env` of the extension, potentially exposing sensitive keys (OPENAI_API_KEY, GITHUB_TOKEN) to untrusted tools.
+**Learning:** `child_process.spawn` defaults to inheriting `process.env` if `env` is not specified, but here it was explicitly spread. Extensions should follow "Least Privilege" for plugins.
+**Prevention:** Implement an environment filter (`filterSafeEnv`) that only allows system basics and non-sensitive variables, or explicitly whitelist variables.

--- a/backend/modules/mcp/StdioClient.ts
+++ b/backend/modules/mcp/StdioClient.ts
@@ -84,6 +84,46 @@ interface McpPrompt {
 }
 
 /**
+ * 过滤敏感环境变量
+ *
+ * 防止将敏感信息（如 API Key）泄露给 MCP 服务器
+ */
+function filterSafeEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+    const safeEnv: Record<string, string> = {};
+    const sensitiveKeys = /^(?:AZURE_|AWS_|GOOGLE_|OPENAI_|ANTHROPIC_|GITHUB_|GITLAB_|SLACK_|DISCORD_|STRIPE_|TWILIO_|SENDGRID_|PRIVATE_|SECRET_|KEY_|TOKEN_|PASSWORD_|AUTH_|ACCESS_|REFRESH_).*/i;
+    const sensitiveKeywords = /(?:key|token|secret|password|auth|credential)/i;
+
+    const systemBasics = [
+        'HOME', 'USERPROFILE', 'TEMP', 'TMP', 'TMPDIR',
+        'LANG', 'LC_ALL', 'TERM', 'SHELL',
+        'SYSTEMROOT', 'WINDIR', 'APPDATA', 'LOCALAPPDATA',
+        'PROGRAMFILES', 'PROGRAMFILES(X86)', 'COMMONPROGRAMFILES', 'COMSPEC',
+        'PATH', 'PATHEXT'
+    ];
+
+    for (const [key, value] of Object.entries(env)) {
+        if (!value) continue;
+
+        const upperKey = key.toUpperCase();
+
+        // Always allow system basics
+        if (systemBasics.includes(upperKey)) {
+            safeEnv[key] = value;
+            continue;
+        }
+
+        // Filter out sensitive
+        if (sensitiveKeys.test(key) || sensitiveKeywords.test(key)) {
+            continue;
+        }
+
+        // Allow other variables that are not explicitly sensitive
+        safeEnv[key] = value;
+    }
+    return safeEnv;
+}
+
+/**
  * Stdio MCP 客户端
  */
 export class StdioMcpClient extends EventEmitter {
@@ -120,7 +160,7 @@ export class StdioMcpClient extends EventEmitter {
     async connect(): Promise<void> {
         // 启动子进程
         const processEnv = {
-            ...process.env,
+            ...filterSafeEnv(process.env),
             ...this.env
         };
         

--- a/test/stdioEnvLeak.test.ts
+++ b/test/stdioEnvLeak.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as cp from 'child_process';
+import { StdioMcpClient } from '../backend/modules/mcp/StdioClient';
+
+vi.mock('child_process', () => ({
+    spawn: vi.fn(() => ({
+        on: vi.fn(),
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        stdin: { write: vi.fn() },
+        kill: vi.fn(),
+    })),
+}));
+
+describe('StdioMcpClient Environment Safety', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should not inherit sensitive environment variables', async () => {
+        // Setup sensitive env var
+        process.env.OPENAI_API_KEY = 'sk-12345';
+        process.env.GITHUB_TOKEN = 'ghp_abcde';
+        // Ensure PATH exists
+        if (!process.env.PATH) {
+            process.env.PATH = '/usr/bin';
+        }
+
+        const client = new StdioMcpClient('echo', ['hello']);
+
+        // Start connection but don't await it fully
+        client.connect().catch(() => {});
+
+        const spawnCalls = vi.mocked(cp.spawn).mock.calls;
+        expect(spawnCalls.length).toBe(1);
+        const options = spawnCalls[0][2] as any; // 3rd arg is options
+
+        expect(options.env).toBeDefined();
+
+        // Check for leakage
+        const hasOpenAI = options.env?.OPENAI_API_KEY === 'sk-12345';
+        const hasGithub = options.env?.GITHUB_TOKEN === 'ghp_abcde';
+
+        // We expect leakage to be PREVENTED now
+        expect(hasOpenAI).toBe(false);
+        expect(hasGithub).toBe(false);
+        // And PATH should still be there
+        expect(options.env?.PATH).toBeDefined();
+
+        // Cleanup
+        delete process.env.OPENAI_API_KEY;
+        delete process.env.GITHUB_TOKEN;
+    });
+});


### PR DESCRIPTION
MCP servers spawned via stdio transport previously inherited the entire process.env of the extension, potentially exposing sensitive keys (OPENAI_API_KEY, GITHUB_TOKEN) to untrusted tools. This change introduces a filterSafeEnv function that only allows system basics and non-sensitive variables by default.

---
*PR created automatically by Jules for task [11086117379168205421](https://jules.google.com/task/11086117379168205421) started by @Andy963*