### PR TITLE
🎨 Palette: Improve Tooltip accessibility with keyboard support

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Tooltip Accessibility
+**Learning:** Pure hover-based tooltips are inaccessible to keyboard users. Using `focusin`/`focusout` on the wrapper element allows tooltips to appear for keyboard focus without conflicting with click actions.
+**Action:** Always verify interactive components (like tooltips, dropdowns) with keyboard navigation (Tab/Shift+Tab) and screen reader considerations.

--- a/frontend/src/components/common/Tooltip.vue
+++ b/frontend/src/components/common/Tooltip.vue
@@ -14,25 +14,57 @@ const props = withDefaults(defineProps<{
   disabled: false
 })
 
-const visible = ref(false)
+const isHovered = ref(false)
+const isFocused = ref(false)
+
+const visible = computed(() => {
+  return (isHovered.value || isFocused.value) && !props.disabled && !!props.content
+})
 
 const tooltipClass = computed(() => {
   return ['tooltip', props.placement]
 })
 
-function show() {
-  if (!props.disabled && props.content) {
-    visible.value = true
-  }
+function handleMouseEnter() {
+  isHovered.value = true
 }
 
-function hide() {
-  visible.value = false
+function handleMouseLeave() {
+  isHovered.value = false
+}
+
+function handleFocusIn() {
+  isFocused.value = true
+}
+
+function handleFocusOut(event: FocusEvent) {
+  const currentTarget = event.currentTarget as HTMLElement
+  const relatedTarget = event.relatedTarget as HTMLElement
+
+  if (currentTarget.contains(relatedTarget)) {
+    return
+  }
+
+  isFocused.value = false
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    isHovered.value = false
+    isFocused.value = false
+  }
 }
 </script>
 
 <template>
-  <div class="tooltip-wrapper" @mouseenter="show" @mouseleave="hide">
+  <div
+    class="tooltip-wrapper"
+    @mouseenter="handleMouseEnter"
+    @mouseleave="handleMouseLeave"
+    @focusin="handleFocusIn"
+    @focusout="handleFocusOut"
+    @keydown="handleKeydown"
+  >
     <slot />
     <Transition name="tooltip-fade">
       <div


### PR DESCRIPTION
🎨 Palette: Improved Tooltip accessibility

💡 **What:**
Updated `frontend/src/components/common/Tooltip.vue` to support keyboard interaction. Tooltips now appear when the wrapped element receives focus (e.g., via Tab key) and can be dismissed with the Escape key.

🎯 **Why:**
Previous implementation only supported mouse hover, making tooltips inaccessible to keyboard users and screen reader users navigating by focus. This is a critical accessibility gap.

♿ **Accessibility:**
- Added `focusin` and `focusout` listeners to the tooltip wrapper.
- Added `keydown.escape` listener to dismiss the tooltip.
- Ensured tooltips do not disappear if focus moves *within* the tooltip content.

📸 **Verification:**
- Verified that `pnpm build:frontend` passes successfully.
- Manually verified the logic to ensure correct behavior for both mouse and keyboard users.


---
*PR created automatically by Jules for task [13620532618250469899](https://jules.google.com/task/13620532618250469899) started by @Andy963*