### PR TITLE
🎨 Palette: Improve Accessibility for Tooltips and Action Buttons

### DIFF
--- a/frontend/src/components/attachment/AttachmentItem.vue
+++ b/frontend/src/components/attachment/AttachmentItem.vue
@@ -90,6 +90,7 @@ function handleDownload() {
           icon="codicon-eye"
           size="small"
           variant="default"
+          :aria-label="t('components.attachment.preview')"
           @click="handlePreview"
         />
       </Tooltip>
@@ -100,6 +101,7 @@ function handleDownload() {
           icon="codicon-desktop-download"
           size="small"
           variant="default"
+          :aria-label="t('components.attachment.download')"
           @click="handleDownload"
         />
       </Tooltip>
@@ -212,7 +214,8 @@ function handleDownload() {
   transition: opacity 0.15s;
 }
 
-.attachment-item:hover .attachment-actions {
+.attachment-item:hover .attachment-actions,
+.attachment-item:focus-within .attachment-actions {
   opacity: 1;
 }
 </style>

--- a/frontend/src/components/common/Tooltip.vue
+++ b/frontend/src/components/common/Tooltip.vue
@@ -3,7 +3,7 @@
  * 提示框组件
  */
 
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 
 const props = withDefaults(defineProps<{
   content?: string
@@ -29,10 +29,31 @@ function show() {
 function hide() {
   visible.value = false
 }
+
+// Close tooltip on Escape key
+function handleKeydown(e: KeyboardEvent) {
+  if (visible.value && e.key === 'Escape') {
+    hide()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown)
+})
 </script>
 
 <template>
-  <div class="tooltip-wrapper" @mouseenter="show" @mouseleave="hide">
+  <div
+    class="tooltip-wrapper"
+    @mouseenter="show"
+    @mouseleave="hide"
+    @focusin="show"
+    @focusout="hide"
+  >
     <slot />
     <Transition name="tooltip-fade">
       <div

--- a/frontend/src/components/message/MessageList.vue
+++ b/frontend/src/components/message/MessageList.vue
@@ -636,8 +636,12 @@ function formatCheckpointTime(timestamp: number): string {
                 </div>
                 <span v-if="cp.toolName !== 'user_message'" class="checkpoint-time">{{ formatCheckpointTime(cp.timestamp)
                   }}</span>
-                <Tooltip :text="t('components.message.checkpoint.restoreTooltip')">
-                  <button class="checkpoint-action" @click="restoreCheckpoint(cp)">
+                <Tooltip :content="t('components.message.checkpoint.restoreTooltip')">
+                  <button
+                    class="checkpoint-action"
+                    @click="restoreCheckpoint(cp)"
+                    :aria-label="t('components.message.checkpoint.restoreTooltip')"
+                  >
                     <i class="codicon codicon-discard"></i>
                   </button>
                 </Tooltip>
@@ -667,8 +671,12 @@ function formatCheckpointTime(timestamp: number): string {
                   </div>
                   <span v-if="cp.toolName !== 'user_message'" class="checkpoint-time">{{
                     formatCheckpointTime(cp.timestamp) }}</span>
-                  <Tooltip :text="t('components.message.checkpoint.restoreTooltip')">
-                    <button class="checkpoint-action" @click="restoreCheckpoint(cp)">
+                  <Tooltip :content="t('components.message.checkpoint.restoreTooltip')">
+                    <button
+                      class="checkpoint-action"
+                      @click="restoreCheckpoint(cp)"
+                      :aria-label="t('components.message.checkpoint.restoreTooltip')"
+                    >
                       <i class="codicon codicon-discard"></i>
                     </button>
                   </Tooltip>


### PR DESCRIPTION
💡 **What:**
- Enhanced `Tooltip.vue` to show on keyboard focus and close on `Escape`.
- Fixed broken tooltips in `MessageList.vue` by correcting prop usage (`:text` -> `:content`).
- Added `:aria-label` to "Preview", "Download", and "Restore Checkpoint" icon-only buttons.
- Ensured attachment action buttons are visible on focus via CSS (`:focus-within`).

🎯 **Why:**
- Keyboard users could not access tooltips or see action buttons in attachment items.
- Screen reader users had no context for icon-only buttons.
- Tooltips in `MessageList.vue` were not displaying content due to incorrect prop name.

📸 **Before/After:**
- *Before:* Tooltips only appeared on hover. Attachment actions invisible until hovered. Restore buttons had no label.
- *After:* Tooltips appear on focus. Attachment actions appear on focus. All buttons have accessible names.

♿ **Accessibility:**
- Added `aria-label` to icon-only buttons.
- Added keyboard support for tooltips (focus, Escape).
- Improved focus visibility for hidden actions.

---
*PR created automatically by Jules for task [916752683129731555](https://jules.google.com/task/916752683129731555) started by @Andy963*