### PR TITLE
🎨 Palette: Improve Tooltip & Button Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+## 2025-02-23 - Tooltip & Icon Button Accessibility
+**Learning:** `Tooltip` components wrapping `IconButton`s were often visually present but inaccessible to keyboard users and screen readers.
+- `Tooltip.vue` lacked keyboard focus triggers (`focusin/focusout`).
+- `IconButton`s inside tooltips often lacked `aria-label`, relying solely on the visual tooltip for context.
+- Some usages passed incorrect props (`:text` instead of `:content`), causing tooltips to not render at all.
+**Action:** Always ensure `Tooltip` supports keyboard interaction. When wrapping icon-only buttons with `Tooltip`, explicitly pass `aria-label` to the button matching the tooltip content. Verify prop names against component definitions.

--- a/frontend/src/components/attachment/AttachmentItem.vue
+++ b/frontend/src/components/attachment/AttachmentItem.vue
@@ -90,6 +90,7 @@ function handleDownload() {
           icon="codicon-eye"
           size="small"
           variant="default"
+          :aria-label="t('components.attachment.preview')"
           @click="handlePreview"
         />
       </Tooltip>
@@ -100,6 +101,7 @@ function handleDownload() {
           icon="codicon-desktop-download"
           size="small"
           variant="default"
+          :aria-label="t('components.attachment.download')"
           @click="handleDownload"
         />
       </Tooltip>

--- a/frontend/src/components/common/Tooltip.vue
+++ b/frontend/src/components/common/Tooltip.vue
@@ -32,7 +32,7 @@ function hide() {
 </script>
 
 <template>
-  <div class="tooltip-wrapper" @mouseenter="show" @mouseleave="hide">
+  <div class="tooltip-wrapper" @mouseenter="show" @mouseleave="hide" @focusin="show" @focusout="hide">
     <slot />
     <Transition name="tooltip-fade">
       <div

--- a/frontend/src/components/message/MessageList.vue
+++ b/frontend/src/components/message/MessageList.vue
@@ -636,8 +636,8 @@ function formatCheckpointTime(timestamp: number): string {
                 </div>
                 <span v-if="cp.toolName !== 'user_message'" class="checkpoint-time">{{ formatCheckpointTime(cp.timestamp)
                   }}</span>
-                <Tooltip :text="t('components.message.checkpoint.restoreTooltip')">
-                  <button class="checkpoint-action" @click="restoreCheckpoint(cp)">
+                <Tooltip :content="t('components.message.checkpoint.restoreTooltip')">
+                  <button class="checkpoint-action" @click="restoreCheckpoint(cp)" :aria-label="t('components.message.checkpoint.restoreTooltip')">
                     <i class="codicon codicon-discard"></i>
                   </button>
                 </Tooltip>
@@ -667,8 +667,8 @@ function formatCheckpointTime(timestamp: number): string {
                   </div>
                   <span v-if="cp.toolName !== 'user_message'" class="checkpoint-time">{{
                     formatCheckpointTime(cp.timestamp) }}</span>
-                  <Tooltip :text="t('components.message.checkpoint.restoreTooltip')">
-                    <button class="checkpoint-action" @click="restoreCheckpoint(cp)">
+                  <Tooltip :content="t('components.message.checkpoint.restoreTooltip')">
+                    <button class="checkpoint-action" @click="restoreCheckpoint(cp)" :aria-label="t('components.message.checkpoint.restoreTooltip')">
                       <i class="codicon codicon-discard"></i>
                     </button>
                   </Tooltip>


### PR DESCRIPTION
💡 What: Enhanced Tooltip.vue to support keyboard focus and fixed broken tooltips in MessageList.vue.
🎯 Why: Tooltips were inaccessible to keyboard users and broken in MessageList due to incorrect props (using `text` instead of `content`).
♿ Accessibility: Added focusin/focusout support to Tooltips and proper aria-labels to icon buttons in MessageList and AttachmentItem.
📸 Before/After: Visual tooltips now appear on focus for keyboard users. Screen readers announce button purpose correctly. Fixed a bug where restore tooltips were not showing at all.

---
*PR created automatically by Jules for task [5382718631307779675](https://jules.google.com/task/5382718631307779675) started by @Andy963*