### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Enforce command risk assessment in execute_command tool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Unenforced Security Policy in Tool Execution
+**Vulnerability:** The `execute_command` tool was not utilizing the existing `commandRisk.ts` module, allowing high-risk commands (e.g., `rm -rf /`, `curl | sh`) to be executed without any checks or user confirmation.
+**Learning:** Security modules like `commandRisk` are useless if not explicitly integrated into the execution path. Having the policy defined in settings is not enough; the tool handler must enforce it.
+**Prevention:** Ensure all sensitive tools (terminal, file operations) have explicit hooks into the risk assessment system. Add integration tests that verify risk policies are actually enforced, not just that the risk assessment logic works in isolation.

--- a/backend/tools/terminal/execute_command.ts
+++ b/backend/tools/terminal/execute_command.ts
@@ -20,6 +20,7 @@ import type { Tool, ToolResult, ToolContext } from '../types';
 const treeKill = require('tree-kill') as (pid: number, signal?: string, callback?: (error?: Error) => void) => void;
 import { getGlobalSettingsManager } from '../../core/settingsContext';
 import { getDefaultExecuteCommandConfig } from '../../modules/settings';
+import { shouldConfirmExecuteCommand } from '../../core/commandRisk';
 import { TaskManager, type TaskEvent } from '../taskManager';
 import { getAllWorkspaces } from '../utils';
 import { t } from '../../i18n';
@@ -244,6 +245,30 @@ ${getAvailableShellsDescription()}${workspaceDescription}
             // 获取设置管理器和配置
             const settingsManager = getGlobalSettingsManager();
             const config = settingsManager?.getExecuteCommandConfig() || getDefaultExecuteCommandConfig();
+
+            // Security: Risk Assessment
+            const riskPolicy = config.riskPolicy;
+            const { confirm, assessment } = shouldConfirmExecuteCommand(command, riskPolicy);
+
+            if (confirm) {
+                const reasons = assessment.reasons.length > 0 ? assessment.reasons.join(', ') : 'High risk command detected';
+                const message = `⚠️ Security Warning: The command "${command}" is flagged as ${assessment.level.toUpperCase()} risk.\nReasons: ${reasons}.\n\nDo you want to execute it?`;
+
+                const selection = await vscode.window.showWarningMessage(
+                    message,
+                    { modal: true },
+                    'Execute',
+                    'Cancel'
+                );
+
+                if (selection !== 'Execute') {
+                    return {
+                        success: false,
+                        error: `Command execution cancelled by user due to security risk (${assessment.level}: ${reasons}).`,
+                        cancelled: true
+                    };
+                }
+            }
             
             // 确定实际使用的 shell 类型
             let actualShellType = shell;

--- a/test/executeCommandToolRisk.test.ts
+++ b/test/executeCommandToolRisk.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock vscode
+vi.mock('vscode', () => ({
+  window: {
+    showWarningMessage: vi.fn(),
+  },
+  workspace: {
+    workspaceFolders: [{ uri: { fsPath: '/workspace' }, name: 'workspace' }],
+    getWorkspaceFolder: vi.fn(),
+    asRelativePath: vi.fn(),
+  },
+}));
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: vi.fn((event, cb) => {
+      if (event === 'close') cb(0);
+    }),
+    kill: vi.fn(),
+    pid: 123,
+  })),
+}));
+
+// Mock settingsContext
+const mockGetExecuteCommandConfig = vi.fn();
+vi.mock('../backend/core/settingsContext', () => ({
+  getGlobalSettingsManager: () => ({
+    getExecuteCommandConfig: mockGetExecuteCommandConfig,
+  }),
+}));
+
+// Mock cwdValidation
+vi.mock('../backend/tools/terminal/cwdValidation', () => ({
+  resolveExecuteCommandWorkingDir: vi.fn().mockResolvedValue({ ok: true, workingDir: '/workspace' }),
+}));
+
+// Mock executeCommandShells
+vi.mock('../backend/tools/terminal/executeCommandShells', () => ({
+  checkShellAvailability: vi.fn().mockResolvedValue({ available: true }),
+  getShellConfig: vi.fn().mockReturnValue({ shell: 'bash', shellArgs: ['-c'] }),
+  getDefaultShellName: vi.fn().mockReturnValue('bash'),
+  getEnabledShellTypesForEnum: vi.fn().mockReturnValue(['bash']),
+  getAvailableShellsDescription: vi.fn().mockReturnValue('Bash'),
+  getEnabledShellTypes: vi.fn().mockReturnValue(['bash']),
+  checkAllShellsAvailability: vi.fn(),
+}));
+
+// Mock executeCommandWorkspace
+vi.mock('../backend/tools/terminal/executeCommandWorkspace', () => ({
+  getAllWorkspaceRoots: vi.fn().mockReturnValue([{ name: 'workspace', path: '/workspace' }]),
+}));
+
+// Mock executeCommandGitChanges
+vi.mock('../backend/tools/terminal/executeCommandGitChanges', () => ({
+  getGitChangesFingerprint: vi.fn().mockResolvedValue('fingerprint'),
+  collectExecuteCommandChangedFiles: vi.fn().mockResolvedValue({ changedFiles: [], summary: {} }),
+}));
+
+// Mock utils
+vi.mock('../backend/tools/utils', () => ({
+  getAllWorkspaces: vi.fn().mockReturnValue([{ name: 'workspace', fsPath: '/workspace' }]),
+}));
+
+
+import * as vscode from 'vscode';
+import { createExecuteCommandTool } from '../backend/tools/terminal/execute_command';
+import { DEFAULT_EXECUTE_COMMAND_RISK_POLICY } from '../backend/core/commandRisk';
+
+describe('execute_command tool risk assessment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetExecuteCommandConfig.mockReturnValue({
+      defaultShell: 'bash',
+      shells: [{ type: 'bash', enabled: true }],
+      riskPolicy: DEFAULT_EXECUTE_COMMAND_RISK_POLICY,
+    });
+  });
+
+  it('should execute low risk command directly', async () => {
+    const tool = createExecuteCommandTool();
+    const result = await tool.handler({ command: 'echo hello' });
+    expect(result.success).toBe(true);
+    expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+  });
+
+  it('should prompt for high risk command (e.g. rm -rf /)', async () => {
+    const tool = createExecuteCommandTool();
+    // Simulate user rejecting the prompt
+    (vscode.window.showWarningMessage as any).mockResolvedValue('Cancel');
+
+    const result = await tool.handler({ command: 'rm -rf /' });
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+    // Since we haven't implemented it yet, it should actually SUCCEED in current codebase (failing test)
+    // But we expect it to fail once implemented.
+    // For TDD, this test should fail now.
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Command execution cancelled by user due to security risk');
+  });
+
+  it('should execute if user confirms high risk command', async () => {
+    const tool = createExecuteCommandTool();
+    // Simulate user accepting the prompt
+    (vscode.window.showWarningMessage as any).mockResolvedValue('Execute');
+
+    const result = await tool.handler({ command: 'rm -rf /' });
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR enhances the security of the `execute_command` tool by integrating the existing `commandRisk` module. It now assesses the risk of commands before execution and prompts the user for confirmation if the command is deemed high-risk (e.g., `rm -rf /`, `curl | sh`). This prevents accidental or malicious execution of destructive commands by the agent.

Key changes:
- Modified `backend/tools/terminal/execute_command.ts` to use `shouldConfirmExecuteCommand`.
- Added `test/executeCommandToolRisk.test.ts` with comprehensive test cases.
- Added a security journal entry in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1916624471589289275](https://jules.google.com/task/1916624471589289275) started by @Andy963*