### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix environment leak in execute_command tool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2025-02-14 - [CRITICAL] Fix sensitive environment variable leak to child processes
+**Vulnerability:** The `execute_command` tool was passing `process.env` directly to child processes when executing shell commands. This could expose sensitive environment variables (e.g., API keys, secrets) to the shell environment.
+**Learning:** Even though `filterSensitiveEnv` was implemented, it was not being utilized when `execute_command` was creating child processes via `cp.spawn`. This highlights a pattern of defining security measures but failing to apply them at all relevant execution boundaries.
+**Prevention:** Always verify that environment filtering is applied before passing `process.env` to any child process or external execution context. Ensure that tools that execute external commands are rigorously audited for environmental leakages.

--- a/backend/tools/terminal/executeCommand/tool.ts
+++ b/backend/tools/terminal/executeCommand/tool.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import type { Tool, ToolContext, ToolResult } from '../../types';
 
 import { shouldConfirmExecuteCommand } from '../../../core/commandRisk';
+import { filterSensitiveEnv } from '../../../core/envFilter';
 import { getGlobalSettingsManager } from '../../../core/settingsContext';
 import { getDefaultExecuteCommandConfig } from '../../../modules/settings';
 import { TaskManager } from '../../taskManager';
@@ -200,7 +201,7 @@ ${getAvailableShellsDescription()}${workspaceDescription}
                         ? [...shellConfig.shellArgs, finalCommand]
                         : [finalCommand];
 
-                    const env = { ...process.env };
+                    const env = filterSensitiveEnv(process.env);
                     if (isWindows) {
                         if (!env.LANG) env.LANG = 'en_US.UTF-8';
                         if (!env.PYTHONIOENCODING) env.PYTHONIOENCODING = 'utf-8';


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `execute_command` tool passes the entire `process.env` directly to child processes when spawning a shell command. This exposes all environment variables, including potentially sensitive ones like API keys and secrets, to any command executed by the tool.
🎯 Impact: An attacker or a maliciously crafted command could dump or exfiltrate sensitive environment variables, leading to credentials compromise and unauthorized access.
🔧 Fix: Imported the `filterSensitiveEnv` utility and applied it to `process.env` before passing it to `cp.spawn`. This ensures that any variable matching a sensitive pattern is redacted from the child process environment.
✅ Verification: Ran `pnpm test` successfully. Added a journal entry in `.jules/sentinel.md` outlining the issue and prevention.

---
*PR created automatically by Jules for task [10001495436869967146](https://jules.google.com/task/10001495436869967146) started by @Andy963*