### PR TITLE
🎨 Palette: Add ARIA labels and tooltips to MessageActions buttons

### DIFF
--- a/frontend/src/components/message/MessageActions.vue
+++ b/frontend/src/components/message/MessageActions.vue
@@ -7,6 +7,7 @@
 import { ref } from 'vue'
 import { IconButton } from '../common'
 import type { Message } from '../../types'
+import { useI18n } from '../../composables'
 
 defineProps<{
   message: Message
@@ -20,6 +21,8 @@ const emit = defineEmits<{
   delete: []
   retry: []
 }>()
+
+const { t } = useI18n()
 
 // 复制状态
 const isCopied = ref(false)
@@ -53,6 +56,8 @@ function handleCopy() {
       v-if="canEdit"
       icon="codicon-edit"
       size="small"
+      :tooltip="t('common.edit')"
+      :aria-label="t('common.edit')"
       @click="emit('edit')"
     />
 
@@ -60,6 +65,8 @@ function handleCopy() {
     <IconButton
       :icon="isCopied ? 'codicon-check' : 'codicon-copy'"
       size="small"
+      :tooltip="isCopied ? t('common.copied') : t('common.copy')"
+      :aria-label="isCopied ? t('common.copied') : t('common.copy')"
       @click="handleCopy"
     />
 
@@ -68,6 +75,8 @@ function handleCopy() {
       v-if="canRetry"
       icon="codicon-refresh"
       size="small"
+      :tooltip="t('common.retry')"
+      :aria-label="t('common.retry')"
       @click="emit('retry')"
     />
 
@@ -76,6 +85,8 @@ function handleCopy() {
       icon="codicon-trash"
       size="small"
       variant="danger"
+      :tooltip="t('common.delete')"
+      :aria-label="t('common.delete')"
       @click="emit('delete')"
     />
   </div>


### PR DESCRIPTION
Adds accessibility and usability improvements to the `MessageActions.vue` component.

### 💡 What:
Added missing `:aria-label` and `:tooltip` properties to the `IconButton` instances for "Edit", "Copy", "Retry", and "Delete" actions. 

### 🎯 Why:
The buttons are icon-only and previously lacked any visual or screen-reader indication of their function. This improves both accessibility (ARIA) and general user experience (hover tooltips).

### ♿ Accessibility: 
Screen readers will now properly announce the function of the message action buttons (e.g. "Copy", "Delete"). 

Also fixed the implementation to use `useI18n()` composable over static `t` imports to prevent reactivity bugs on language switches.

---
*PR created automatically by Jules for task [8071471150944576201](https://jules.google.com/task/8071471150944576201) started by @Andy963*