### PR TITLE
🎨 Palette: Add missing ARIA labels to icon-only buttons in MessageList

### DIFF
--- a/frontend/src/components/message/MessageList.vue
+++ b/frontend/src/components/message/MessageList.vue
@@ -88,7 +88,7 @@ const {
                 <span v-if="cp.toolName !== 'user_message'" class="checkpoint-time">{{ formatCheckpointTime(cp.timestamp)
                   }}</span>
                 <Tooltip :text="t('components.message.checkpoint.restoreTooltip')">
-                  <button class="checkpoint-action" @click="restoreCheckpoint(cp)">
+                    <button class="checkpoint-action" @click="restoreCheckpoint(cp)" :aria-label="t('components.message.checkpoint.restoreTooltip')">
                     <i class="codicon codicon-discard"></i>
                   </button>
                 </Tooltip>
@@ -119,7 +119,7 @@ const {
                   <span v-if="cp.toolName !== 'user_message'" class="checkpoint-time">{{
                     formatCheckpointTime(cp.timestamp) }}</span>
                   <Tooltip :text="t('components.message.checkpoint.restoreTooltip')">
-                    <button class="checkpoint-action" @click="restoreCheckpoint(cp)">
+                      <button class="checkpoint-action" @click="restoreCheckpoint(cp)" :aria-label="t('components.message.checkpoint.restoreTooltip')">
                       <i class="codicon codicon-discard"></i>
                     </button>
                   </Tooltip>
@@ -166,15 +166,18 @@ const {
             <div class="error-icon">⚠</div>
             <div class="error-title">{{ t('components.message.error.title') }}</div>
             <div class="error-actions">
-              <button class="error-retry" @click="handleErrorRetry" :title="t('components.message.error.retry')">
+              <button class="error-retry" @click="handleErrorRetry" :title="t('components.message.error.retry')"
+                :aria-label="t('components.message.error.retry')">
                 <span class="codicon codicon-refresh"></span>
               </button>
               <button class="error-copy" @click="copyErrorDetails"
-                :title="errorCopied ? t('common.copied') : t('components.message.error.copy')">
+                :title="errorCopied ? t('common.copied') : t('components.message.error.copy')"
+                :aria-label="errorCopied ? t('common.copied') : t('components.message.error.copy')">
                 <span :class="['codicon', errorCopied ? 'codicon-check' : 'codicon-copy']"></span>
               </button>
               <button class="error-dismiss" @click="chatStore.error = null"
-                :title="t('components.message.error.dismiss')">
+                :title="t('components.message.error.dismiss')"
+                :aria-label="t('components.message.error.dismiss')">
                 ✕
               </button>
             </div>


### PR DESCRIPTION
**🎨 Palette: Add missing ARIA labels to icon-only buttons**

💡 **What:** Added `aria-label` attributes to the `checkpoint-action`, `error-retry`, `error-copy`, and `error-dismiss` icon-only buttons in `MessageList.vue`.
🎯 **Why:** To improve accessibility by ensuring screen readers can articulate the purpose of these buttons, which only display icons visually. This aligns with our UX standard for accessible buttons.
♿ **Accessibility:** Users relying on screen readers can now understand what the restore and error action buttons do without visual context.

---
*PR created automatically by Jules for task [16027897825019681130](https://jules.google.com/task/16027897825019681130) started by @Andy963*