### PR TITLE
🛡️ Sentinel: [HIGH] Add privilege escalation and arbitrary command execution detection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-17 - [Add Privilege Escalation and Arbitrary Command Execution Risk Detection]
+**Vulnerability:** The command execution risk assessment lacked checks for certain dangerous privilege-escalating and arbitrary command execution operations such as `chmod`, `chown`, `eval`, `ssh`, and `scp`. Without these checks, an AI acting on behalf of a user could execute shell evaluation or grant extensive permissions to scripts implicitly.
+**Learning:** Checking for network pipes (`curl | bash`) and destructive operations (`rm -rf`) is not enough for an arbitrary command execution engine. Privilege escalation tools and dynamic string evaluation operations (like `eval`) are common vectors for bypassing simpler static analysis.
+**Prevention:** Extend command risk categories to capture commands modifying execution capabilities (`chmod`, `chown`) and executing string literals (`eval`).

--- a/backend/core/commandRisk.ts
+++ b/backend/core/commandRisk.ts
@@ -83,8 +83,20 @@ function computeRiskFromCommand(command: string): Omit<CommandRiskAssessment, 'm
     reasons.push('includes sudo');
   }
 
+  const hasChmodChown = /(^|\s)(chmod|chown)\b/.test(lower);
+  if (hasChmodChown) {
+    categories.push('privilege');
+    reasons.push('modifies file permissions or ownership');
+  }
+
+  const hasEval = /(^|\s)eval\b/.test(lower);
+  if (hasEval) {
+    categories.push('privilege');
+    reasons.push('executes arbitrary string as command');
+  }
+
   const hasNetwork =
-    /(^|\s)(curl|wget)\b/.test(lower) ||
+    /(^|\s)(curl|wget|ssh|scp)\b/.test(lower) ||
     /\b(npm|pnpm|yarn|pip|pip3)\s+(install|add)\b/.test(lower) ||
     /\bgit\s+clone\b/.test(lower);
   if (hasNetwork) {
@@ -154,9 +166,11 @@ function computeRiskFromCommand(command: string): Omit<CommandRiskAssessment, 'm
       level = 'high';
     } else if ((isRm || isRmdir || isWindowsDelete) && (hasForceDeleteFlag || hasRecursiveFlag)) {
       level = 'high';
+    } else if (hasEval) {
+      level = 'high';
     } else if (isGitRestore || hasRedirection) {
       level = 'medium';
-    } else if (hasSudo || hasNetwork) {
+    } else if (hasSudo || hasNetwork || hasChmodChown) {
       level = 'medium';
     }
   }

--- a/test/commandRisk.test.ts
+++ b/test/commandRisk.test.ts
@@ -22,6 +22,35 @@ describe('assessExecuteCommandRisk', () => {
     expect(risk.reasons).toContain('includes sudo');
   });
 
+  it('flags chmod and chown as privilege and medium risk', () => {
+    const chmodRisk = assessExecuteCommandRisk('chmod 777 file.txt');
+    expect(chmodRisk.level).toBe('medium');
+    expect(chmodRisk.categories).toContain('privilege');
+    expect(chmodRisk.reasons).toContain('modifies file permissions or ownership');
+
+    const chownRisk = assessExecuteCommandRisk('chown user file.txt');
+    expect(chownRisk.level).toBe('medium');
+    expect(chownRisk.categories).toContain('privilege');
+    expect(chownRisk.reasons).toContain('modifies file permissions or ownership');
+  });
+
+  it('flags eval as privilege and high risk', () => {
+    const risk = assessExecuteCommandRisk('eval "echo hi"');
+    expect(risk.level).toBe('high');
+    expect(risk.categories).toContain('privilege');
+    expect(risk.reasons).toContain('executes arbitrary string as command');
+  });
+
+  it('flags ssh and scp as network and medium risk', () => {
+    const sshRisk = assessExecuteCommandRisk('ssh user@host');
+    expect(sshRisk.level).toBe('medium');
+    expect(sshRisk.categories).toContain('network');
+
+    const scpRisk = assessExecuteCommandRisk('scp file user@host:');
+    expect(scpRisk.level).toBe('medium');
+    expect(scpRisk.categories).toContain('network');
+  });
+
   it('flags output redirection as destructive and medium risk', () => {
     const risk = assessExecuteCommandRisk('echo hi > out.txt');
     expect(risk.level).toBe('medium');


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `execute_command` risk assessment engine lacked explicit checks for privilege-modifying commands (`chmod`, `chown`), arbitrary execution via string evaluation (`eval`), and remote connections (`ssh`, `scp`). This omission could allow AI agents or automated scripts to execute potentially destructive actions or grant excessive permissions without triggering higher risk warnings and confirmation prompts.
🎯 **Impact:** If exploited or hallucinated by the agent, this could result in local privilege escalation, unauthorized file exposure, or bypassed security restrictions via string obfuscation inside `eval`.
🔧 **Fix:** Expanded the regex-based risk categorization in `backend/core/commandRisk.ts` to explicitly capture and flag these command prefixes, appropriately mapping them to the `privilege` and `network` categories with medium and high risk levels.
✅ **Verification:** Hand-verified the logic in the unit tests (`test/commandRisk.test.ts`), and ensured all tests successfully pass with `pnpm test`. Compilation logic is unaffected.

---
*PR created automatically by Jules for task [6616700198901562307](https://jules.google.com/task/6616700198901562307) started by @Andy963*