### PR TITLE
fix: filter execute_command child env

### DIFF
--- a/backend/tools/terminal/executeCommand/tool.ts
+++ b/backend/tools/terminal/executeCommand/tool.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import type { Tool, ToolContext, ToolResult } from '../../types';
 
 import { shouldConfirmExecuteCommand } from '../../../core/commandRisk';
+import { filterSensitiveEnv } from '../../../core/envFilter';
 import { getGlobalSettingsManager } from '../../../core/settingsContext';
 import { getDefaultExecuteCommandConfig } from '../../../modules/settings';
 import { TaskManager } from '../../taskManager';
@@ -200,7 +201,7 @@ ${getAvailableShellsDescription()}${workspaceDescription}
                         ? [...shellConfig.shellArgs, finalCommand]
                         : [finalCommand];
 
-                    const env = { ...process.env };
+                    const env = filterSensitiveEnv(process.env);
                     if (isWindows) {
                         if (!env.LANG) env.LANG = 'en_US.UTF-8';
                         if (!env.PYTHONIOENCODING) env.PYTHONIOENCODING = 'utf-8';

--- a/test/executeCommandToolRisk.test.ts
+++ b/test/executeCommandToolRisk.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as cp from 'child_process';
 
 vi.mock('vscode', () => ({
   window: {
@@ -100,5 +101,30 @@ describe('execute_command risk gating', () => {
 
     expect(vscode.window.showWarningMessage).toHaveBeenCalled();
     expect(result.success).toBe(true);
+  });
+
+  it('filters sensitive env vars before spawning child processes', async () => {
+    process.env.OPENAI_API_KEY = 'sk-test';
+    process.env.GITHUB_TOKEN = 'ghp-test';
+    process.env.PATH = process.env.PATH || '/usr/bin';
+
+    try {
+      const tool = createExecuteCommandTool();
+      const result = await tool.handler({ command: 'echo hello' });
+
+      expect(result.success).toBe(true);
+
+      const spawnCalls = vi.mocked(cp.spawn).mock.calls;
+      expect(spawnCalls.length).toBeGreaterThan(0);
+
+      const options = spawnCalls.at(-1)?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      expect(options?.env).toBeDefined();
+      expect(options?.env?.OPENAI_API_KEY).toBeUndefined();
+      expect(options?.env?.GITHUB_TOKEN).toBeUndefined();
+      expect(options?.env?.PATH).toBeDefined();
+    } finally {
+      delete process.env.OPENAI_API_KEY;
+      delete process.env.GITHUB_TOKEN;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- apply `filterSensitiveEnv(process.env)` at the `execute_command` child-process spawn boundary
- add regression coverage to verify sensitive env keys do not reach spawned commands
- keep the fix narrowly scoped and exclude Jules-specific `.jules` journal artifacts

## Validation
- `npm run compile`
- `npm test`
- `npm run build`

Closes #42
