### PR TITLE
fix: harden execute_command risk detection

### DIFF
--- a/backend/core/commandRisk.ts
+++ b/backend/core/commandRisk.ts
@@ -83,8 +83,20 @@ function computeRiskFromCommand(command: string): Omit<CommandRiskAssessment, 'm
     reasons.push('includes sudo');
   }
 
+  const hasPermissionMutation = /(^|\s)(chmod|chown)\b/.test(lower);
+  if (hasPermissionMutation) {
+    categories.push('privilege');
+    reasons.push('modifies file permissions or ownership');
+  }
+
+  const hasEval = /(^|\s)eval\b/.test(lower);
+  if (hasEval) {
+    categories.push('privilege');
+    reasons.push('executes arbitrary string as command');
+  }
+
   const hasNetwork =
-    /(^|\s)(curl|wget)\b/.test(lower) ||
+    /(^|\s)(curl|wget|ssh|scp)\b/.test(lower) ||
     /\b(npm|pnpm|yarn|pip|pip3)\s+(install|add)\b/.test(lower) ||
     /\bgit\s+clone\b/.test(lower);
   if (hasNetwork) {
@@ -154,9 +166,11 @@ function computeRiskFromCommand(command: string): Omit<CommandRiskAssessment, 'm
       level = 'high';
     } else if ((isRm || isRmdir || isWindowsDelete) && (hasForceDeleteFlag || hasRecursiveFlag)) {
       level = 'high';
+    } else if (hasEval) {
+      level = 'high';
     } else if (isGitRestore || hasRedirection) {
       level = 'medium';
-    } else if (hasSudo || hasNetwork) {
+    } else if (hasSudo || hasNetwork || hasPermissionMutation) {
       level = 'medium';
     }
   }

--- a/test/commandRisk.test.ts
+++ b/test/commandRisk.test.ts
@@ -22,6 +22,35 @@ describe('assessExecuteCommandRisk', () => {
     expect(risk.reasons).toContain('includes sudo');
   });
 
+  it('flags chmod and chown as privilege and medium risk', () => {
+    const chmodRisk = assessExecuteCommandRisk('chmod 777 file.txt');
+    expect(chmodRisk.level).toBe('medium');
+    expect(chmodRisk.categories).toContain('privilege');
+    expect(chmodRisk.reasons).toContain('modifies file permissions or ownership');
+
+    const chownRisk = assessExecuteCommandRisk('chown user file.txt');
+    expect(chownRisk.level).toBe('medium');
+    expect(chownRisk.categories).toContain('privilege');
+    expect(chownRisk.reasons).toContain('modifies file permissions or ownership');
+  });
+
+  it('flags eval as privilege and high risk', () => {
+    const risk = assessExecuteCommandRisk('eval "echo hi"');
+    expect(risk.level).toBe('high');
+    expect(risk.categories).toContain('privilege');
+    expect(risk.reasons).toContain('executes arbitrary string as command');
+  });
+
+  it('flags ssh and scp as network and medium risk', () => {
+    const sshRisk = assessExecuteCommandRisk('ssh user@host');
+    expect(sshRisk.level).toBe('medium');
+    expect(sshRisk.categories).toContain('network');
+
+    const scpRisk = assessExecuteCommandRisk('scp file user@host:');
+    expect(scpRisk.level).toBe('medium');
+    expect(scpRisk.categories).toContain('network');
+  });
+
   it('flags output redirection as destructive and medium risk', () => {
     const risk = assessExecuteCommandRisk('echo hi > out.txt');
     expect(risk.level).toBe('medium');


### PR DESCRIPTION
## Summary
- extend `assessExecuteCommandRisk` to recognize `chmod`, `chown`, `eval`, `ssh`, and `scp`
- classify permission changes as privilege risk, `eval` as high privilege risk, and remote command/file transfer as network risk
- add regression coverage for the new command categories without carrying Jules-specific `.jules` artifacts

## Validation
- `npm run compile`
- `npm test`
- `npm run build`

Closes #44
