### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons in MessageList

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - Icon-only button a11y & Tooltip prop consistency
+**Learning:** Found multiple icon-only buttons in the error state of `MessageList.vue` without `aria-label` attributes. Additionally, discovered that the `Tooltip` component uses a `content` prop instead of `text`, which was being misused in `MessageList.vue`.
+**Action:** Added explicit `aria-label`s to all icon-only buttons (`retry`, `copy`, `dismiss`, `restore checkpoint`) based on their tooltip text or existing `title` attributes. Corrected the `Tooltip` component prop from `:text` to `:content` to ensure accessibility and proper tooltip rendering.

--- a/frontend/src/components/message/MessageList.vue
+++ b/frontend/src/components/message/MessageList.vue
@@ -87,8 +87,8 @@ const {
                 </div>
                 <span v-if="cp.toolName !== 'user_message'" class="checkpoint-time">{{ formatCheckpointTime(cp.timestamp)
                   }}</span>
-                <Tooltip :text="t('components.message.checkpoint.restoreTooltip')">
-                  <button class="checkpoint-action" @click="restoreCheckpoint(cp)">
+                <Tooltip :content="t('components.message.checkpoint.restoreTooltip')">
+                  <button class="checkpoint-action" @click="restoreCheckpoint(cp)" :aria-label="t('components.message.checkpoint.restoreTooltip')">
                     <i class="codicon codicon-discard"></i>
                   </button>
                 </Tooltip>
@@ -118,8 +118,8 @@ const {
                   </div>
                   <span v-if="cp.toolName !== 'user_message'" class="checkpoint-time">{{
                     formatCheckpointTime(cp.timestamp) }}</span>
-                  <Tooltip :text="t('components.message.checkpoint.restoreTooltip')">
-                    <button class="checkpoint-action" @click="restoreCheckpoint(cp)">
+                  <Tooltip :content="t('components.message.checkpoint.restoreTooltip')">
+                    <button class="checkpoint-action" @click="restoreCheckpoint(cp)" :aria-label="t('components.message.checkpoint.restoreTooltip')">
                       <i class="codicon codicon-discard"></i>
                     </button>
                   </Tooltip>
@@ -166,15 +166,16 @@ const {
             <div class="error-icon">⚠</div>
             <div class="error-title">{{ t('components.message.error.title') }}</div>
             <div class="error-actions">
-              <button class="error-retry" @click="handleErrorRetry" :title="t('components.message.error.retry')">
+              <button class="error-retry" @click="handleErrorRetry" :title="t('components.message.error.retry')" :aria-label="t('components.message.error.retry')">
                 <span class="codicon codicon-refresh"></span>
               </button>
               <button class="error-copy" @click="copyErrorDetails"
-                :title="errorCopied ? t('common.copied') : t('components.message.error.copy')">
+                :title="errorCopied ? t('common.copied') : t('components.message.error.copy')"
+                :aria-label="errorCopied ? t('common.copied') : t('components.message.error.copy')">
                 <span :class="['codicon', errorCopied ? 'codicon-check' : 'codicon-copy']"></span>
               </button>
               <button class="error-dismiss" @click="chatStore.error = null"
-                :title="t('components.message.error.dismiss')">
+                :title="t('components.message.error.dismiss')" :aria-label="t('components.message.error.dismiss')">
                 ✕
               </button>
             </div>


### PR DESCRIPTION
💡 **What:** 
- Added `aria-label` to the `Restore Checkpoint`, `Retry`, `Copy Error Details`, and `Dismiss` buttons in `MessageList.vue`.
- Updated the `Tooltip` component usage around the `Restore Checkpoint` button to correctly pass the `content` prop instead of `text`.

🎯 **Why:** 
Screen readers could not interpret these buttons because they lacked an accessible name. Additionally, the incorrect `text` prop on `Tooltip` meant the tooltip text might not have been rendering as expected, which also impacts usability.

♿ **Accessibility:**
- Ensures icon-only error and checkpoint action buttons meet WCAG 2.1 4.1.2 Name, Role, Value by providing explicit `aria-label`s.

---
*PR created automatically by Jules for task [10140597486152443174](https://jules.google.com/task/10140597486152443174) started by @Andy963*