### PR TITLE
⚡ Bolt: Cache compiled RegExp in matchGlobPattern

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - [Regex Compilation in File Iteration]
+**Learning:** The application evaluates glob and ignore patterns on every file during directory traversal (e.g. `shouldIgnorePath` using `matchGlobPattern`). Repeatedly calling `new RegExp` for the same string patterns inside recursive file traversal creates significant GC pressure and CPU overhead, especially in large workspaces.
+**Action:** Always use a module-level `Map` cache (e.g., `GLOB_REGEX_CACHE = new Map<string, RegExp>()`) for compiled `RegExp` objects when evaluating static patterns against large file trees, with a reasonable max size (e.g. 2048) to prevent memory leaks.

--- a/backend/modules/prompt/ignorePatterns.ts
+++ b/backend/modules/prompt/ignorePatterns.ts
@@ -7,19 +7,31 @@ export function shouldIgnorePath(relativePath: string, ignorePatterns: string[])
   return false;
 }
 
-export function matchGlobPattern(inputPath: string, pattern: string): boolean {
-  const regexPattern = pattern
-    .replace(/\\/g, '/')
-    .replace(/\./g, '\\.')
-    .replace(/\*\*/g, '<<<GLOBSTAR>>>')
-    .replace(/\*/g, '[^/]*')
-    .replace(/<<<GLOBSTAR>>>/g, '.*')
-    .replace(/\//g, '[/\\\\]');
+const GLOB_REGEX_CACHE = new Map<string, RegExp>();
+const GLOB_REGEX_CACHE_MAX_SIZE = 2048;
 
-  const regex = new RegExp(
-    `^${regexPattern}$|[/\\\\]${regexPattern}$|^${regexPattern}[/\\\\]|[/\\\\]${regexPattern}[/\\\\]`,
-    'i'
-  );
+export function matchGlobPattern(inputPath: string, pattern: string): boolean {
+  let regex = GLOB_REGEX_CACHE.get(pattern);
+
+  if (!regex) {
+    const regexPattern = pattern
+      .replace(/\\/g, '/')
+      .replace(/\./g, '\\.')
+      .replace(/\*\*/g, '<<<GLOBSTAR>>>')
+      .replace(/\*/g, '[^/]*')
+      .replace(/<<<GLOBSTAR>>>/g, '.*')
+      .replace(/\//g, '[/\\\\]');
+
+    regex = new RegExp(
+      `^${regexPattern}$|[/\\\\]${regexPattern}$|^${regexPattern}[/\\\\]|[/\\\\]${regexPattern}[/\\\\]`,
+      'i'
+    );
+
+    if (GLOB_REGEX_CACHE.size >= GLOB_REGEX_CACHE_MAX_SIZE) {
+      GLOB_REGEX_CACHE.clear();
+    }
+    GLOB_REGEX_CACHE.set(pattern, regex);
+  }
 
   return regex.test(inputPath.replace(/\\/g, '/'));
 }


### PR DESCRIPTION
💡 What: Implemented a module-level `Map` cache (`GLOB_REGEX_CACHE`) in `backend/modules/prompt/ignorePatterns.ts` to store compiled `RegExp` objects for glob patterns.
🎯 Why: File traversals repeatedly check if files should be ignored by compiling the same ignore patterns into `RegExp` objects inside recursive loops. This creates significant garbage collection (GC) pressure and CPU overhead in large workspaces.
📊 Impact: Reduces repetitive `new RegExp` instantiations to exactly O(1) compiled copies per unique glob pattern, resulting in measurable CPU savings during extensive workspace file traversals.
🔬 Measurement: Verify by executing file traversal commands on a large workspace with numerous `.gitignore` and glob rules, monitoring CPU and memory usage to observe reduced spikes and faster processing times.

---
*PR created automatically by Jules for task [2345837673673183819](https://jules.google.com/task/2345837673673183819) started by @Andy963*